### PR TITLE
Issue #69 implement

### DIFF
--- a/DEMO/Release/HelloWorld.ecla
+++ b/DEMO/Release/HelloWorld.ecla
@@ -5,3 +5,7 @@ import "console";
 #/ this is a block comment /#
 
 console.println("Hello, World!");
+
+var x int;
+var y int = 1;
+var z := 1;

--- a/DEMO/Release/HelloWorld.ecla
+++ b/DEMO/Release/HelloWorld.ecla
@@ -5,7 +5,3 @@ import "console";
 #/ this is a block comment /#
 
 console.println("Hello, World!");
-
-var x int;
-var y int = 1;
-var z := 1;

--- a/DEMO/Test/variableDeclaration.ecla
+++ b/DEMO/Test/variableDeclaration.ecla
@@ -1,0 +1,11 @@
+import "console";
+
+
+var x int;
+console.println(x);
+var y int = 1;
+console.println(y);
+var z := 1;
+console.println(z);
+u := 1;
+console.println(u);

--- a/interpreter/eclaType/var.go
+++ b/interpreter/eclaType/var.go
@@ -189,7 +189,9 @@ func NewVar(name string, Type string, value Type) (*Var, error) {
 			Value: value.GetString(),
 		}, nil
 	}
-	if Type != value.GetType() && !value.IsNull() {
+	if Type == "" {
+		Type = value.GetType()
+	} else if Type != value.GetType() && !value.IsNull() {
 		return nil, errors.New("cannot create variable of type " + Type + " with value of type " + value.GetType())
 	}
 	if value.IsNull() {

--- a/parser/Parser.go
+++ b/parser/Parser.go
@@ -244,6 +244,9 @@ func (p *Parser) ParseIdent() Node {
 		return p.ParseMethodCallExpr()
 	} else if p.Peek(1).TokenType == lexer.LPAREN {
 		return p.ParseFunctionCallExpr()
+	} else if p.Peek(1).TokenType == lexer.COLON {
+		p.Back()
+		return p.ParseVariableDecl()
 	} else {
 		return p.ParseVariableAssign()
 	}

--- a/parser/Parser.go
+++ b/parser/Parser.go
@@ -246,7 +246,7 @@ func (p *Parser) ParseIdent() Node {
 		return p.ParseFunctionCallExpr()
 	} else if p.Peek(1).TokenType == lexer.COLON {
 		p.Back()
-		return p.ParseVariableDecl()
+		return p.ParseImplicitVariableDecl()
 	} else {
 		return p.ParseVariableAssign()
 	}
@@ -468,27 +468,39 @@ func (p *Parser) ParseVariableDecl() Decl {
 		p.HandleFatal("Expected variable name instead of " + p.CurrentToken.Value)
 	}
 	tempDecl.Name = p.CurrentToken.Value
-	// make a lookahed to see if the next token is a type or an implicit variable declaration
-	lookAhead := p.Peek(1)
-	if lookAhead.TokenType != lexer.COLON {
-		typeName, success := p.ParseType()
-		if !success {
-			p.HandleFatal("Expected variable type instead of " + p.CurrentToken.Value)
+	typeName, success := p.ParseType()
+	if !success {
+		p.HandleFatal("Expected variable type instead of " + p.CurrentToken.Value)
+	}
+	tempDecl.Type = typeName
+	if p.CurrentToken.TokenType != lexer.ASSIGN {
+		if p.CurrentToken.TokenType != lexer.COMMA && p.CurrentToken.TokenType != lexer.EOL && p.CurrentToken.TokenType != lexer.EOF {
+			p.HandleFatal("Expected variable assignment instead of " + p.CurrentToken.Value)
 		}
-		tempDecl.Type = typeName
-		if p.CurrentToken.TokenType != lexer.ASSIGN {
-			if p.CurrentToken.TokenType != lexer.COMMA && p.CurrentToken.TokenType != lexer.EOL && p.CurrentToken.TokenType != lexer.EOF {
-				p.HandleFatal("Expected variable assignment instead of " + p.CurrentToken.Value)
-			}
-			tempDecl.Value = nil
-			p.CurrentFile.VariableDecl = append(p.CurrentFile.VariableDecl, tempDecl.Name)
-			return tempDecl
+		tempDecl.Value = nil
+		p.CurrentFile.VariableDecl = append(p.CurrentFile.VariableDecl, tempDecl.Name)
+		return tempDecl
+	}
+	p.Step()
+	tempDecl.Value = p.ParseExpr()
+	p.CurrentFile.VariableDecl = append(p.CurrentFile.VariableDecl, tempDecl.Name)
+	return tempDecl
+}
+
+func (p *Parser) ParseImplicitVariableDecl() Decl {
+	tempDecl := VariableDecl{VarToken: p.CurrentToken}
+	p.Step()
+	if p.CurrentToken.TokenType == lexer.TEXT {
+		if _, ok := Keywords[p.CurrentToken.Value]; ok {
+			p.HandleFatal("Cannot use keyword " + p.CurrentToken.Value + " as variable name")
 		}
 	} else {
-		p.MultiStep(2)
-		if p.CurrentToken.TokenType != lexer.ASSIGN {
-			p.HandleFatal("Expected implicit variable assignment instead of " + p.CurrentToken.Value)
-		}
+		p.HandleFatal("Expected variable name instead of " + p.CurrentToken.Value)
+	}
+	tempDecl.Name = p.CurrentToken.Value
+	p.MultiStep(2)
+	if p.CurrentToken.TokenType != lexer.ASSIGN {
+		p.HandleFatal("Expected implicit variable assignment instead of " + p.CurrentToken.Value)
 	}
 	p.Step()
 	tempDecl.Value = p.ParseExpr()


### PR DESCRIPTION
the syntax
```ecla
i := 0;
```
is now valid. It will automatically detect the type int and assign it normally to the var i