### PR TITLE
implemented char in for range loops

### DIFF
--- a/interpreter/Stmt.go
+++ b/interpreter/Stmt.go
@@ -309,7 +309,7 @@ func RunForStmt(For parser.ForStmt, env *Env) *Bus {
 			typ = list.(*eclaType.List).GetType()[2:]
 			l = list.(*eclaType.List).Len()
 		case eclaType.String:
-			typ = list.GetType()
+			typ = "char"
 			l = list.(eclaType.String).Len()
 		case *eclaType.Var:
 			temp := list.(*eclaType.Var).GetValue()
@@ -319,7 +319,7 @@ func RunForStmt(For parser.ForStmt, env *Env) *Bus {
 				typ = temp.(*eclaType.List).GetType()[2:]
 				l = temp.(*eclaType.List).Len()
 			case eclaType.String:
-				typ = temp.(eclaType.String).GetType()
+				typ = "char"
 				l = temp.(eclaType.String).Len()
 			default:
 				env.ErrorHandle.HandleError(0, f.RangeExpr.StartPos(), "for range: type "+list.GetType()+" not supported", errorHandler.LevelFatal)

--- a/interpreter/eclaType/var.go
+++ b/interpreter/eclaType/var.go
@@ -2,7 +2,6 @@ package eclaType
 
 import (
 	"errors"
-
 	"github.com/Eclalang/Ecla/parser"
 )
 


### PR DESCRIPTION
Stmt.go still asked for a string, while string.index returned a char.