### PR TITLE
81.5% code coverage

### DIFF
--- a/interpreter/eclaType/char_test.go
+++ b/interpreter/eclaType/char_test.go
@@ -996,6 +996,26 @@ func TestDivCharErr(t *testing.T) {
 	}
 }
 
+func TestDivBy0CharErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Char(0)
+
+	_, err := t1.Div(t2)
+	if err == nil {
+		t.Error("Expected error when dividing a char by 0")
+	}
+}
+
+func TestDivBy0CharIntErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Int(0)
+
+	_, err := t1.Div(t2)
+	if err == nil {
+		t.Error("Expected error when dividing a char by 0")
+	}
+}
+
 func TestModCharErr(t *testing.T) {
 	t1 := Char('A')
 	t2 := Bool(true)
@@ -1006,6 +1026,26 @@ func TestModCharErr(t *testing.T) {
 	}
 }
 
+func TestModBy0CharErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Char(0)
+
+	_, err := t1.Mod(t2)
+	if err == nil {
+		t.Error("Expected error when modding a char by 0")
+	}
+}
+
+func TestModBy0CharIntErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Int(0)
+
+	_, err := t1.Mod(t2)
+	if err == nil {
+		t.Error("Expected error when modding a char by 0")
+	}
+}
+
 func TestDivEcCharErr(t *testing.T) {
 	t1 := Char('A')
 	t2 := Bool(true)
@@ -1013,6 +1053,26 @@ func TestDivEcCharErr(t *testing.T) {
 	_, err := t1.DivEc(t2)
 	if err == nil {
 		t.Error("Expected error when dividing a char by a bool")
+	}
+}
+
+func TestDivEcBy0CharErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Char(0)
+
+	_, err := t1.DivEc(t2)
+	if err == nil {
+		t.Error("Expected error when dividing a char by 0")
+	}
+}
+
+func TestDivEcBy0CharIntErr(t *testing.T) {
+	t1 := Char('A')
+	t2 := Int(0)
+
+	_, err := t1.DivEc(t2)
+	if err == nil {
+		t.Error("Expected error when dividing a char by 0")
 	}
 }
 


### PR DESCRIPTION
everything is covered, except for the ugly "case *Var" syntax, as shown below

![image](https://github.com/Eclalang/Ecla/assets/43825023/c1d2c29a-a916-4828-afe6-d35fbc5236f5)
